### PR TITLE
Tell mysql to use the database before attempting to add tables to it

### DIFF
--- a/lugDBinit.sql
+++ b/lugDBinit.sql
@@ -1,5 +1,7 @@
 CREATE DATABASE LUGDB;
 
+USE LUGDB;
+
 CREATE TABLE memberType(
   memTypeRef int,
   memTypeName varchar(30)


### PR DESCRIPTION
`USE LUGDB;` must be declared before attempting to modify a database, otherwise mysql won't know what database should be modified.